### PR TITLE
Update index.html

### DIFF
--- a/Sort Without Articles/index.html
+++ b/Sort Without Articles/index.html
@@ -64,7 +64,7 @@ bands.sort((a,b)=>{
 
 
 titleList.innerHTML = bands.map((band)=>{
-return `<li>${band}</li>`});
+return `<li>${band}</li>`}).join('');
 
 </script>
 


### PR DESCRIPTION
added join(' ') on line 67 because by default the template literals use the toString() function to map which adds a comma between consecutive elements.

SRC - https://stackoverflow.com/questions/45812160/unexpected-comma-using-map/45812277